### PR TITLE
Update default API  server url

### DIFF
--- a/gogi.go
+++ b/gogi.go
@@ -9,7 +9,7 @@ import (
 const (
 	version       = "0.0.4"
 	ua            = "gogi/" + version
-	defaultAPIURL = "https://www.gitignore.io"
+	defaultAPIURL = "https://www.toptal.com/developers/gitignore"
 	typePath      = "/api"
 )
 

--- a/gogi.go
+++ b/gogi.go
@@ -9,8 +9,8 @@ import (
 const (
 	version       = "0.0.4"
 	ua            = "gogi/" + version
-	defaultAPIURL = "https://www.toptal.com/developers/gitignore"
-	typePath      = "/api"
+	defaultAPIURL = "https://www.toptal.com"
+	typePath      = "/developers/gitignore/api"
 )
 
 // Client for querying API


### PR DESCRIPTION
Base on gitignore documentation, the API server url is changed from https://www.gitignore.io to
www.toptal.com domain, so use that url instead.

See: https://docs.gitignore.io/install/command-line

Fixes #1