### PR TITLE
Update new default API server

### DIFF
--- a/gogi.go
+++ b/gogi.go
@@ -9,8 +9,8 @@ import (
 const (
 	version       = "0.0.4"
 	ua            = "gogi/" + version
-	defaultAPIURL = "https://www.gitignore.io"
-	typePath      = "/api"
+	defaultAPIURL = "https://docs.gitignore.io"
+	typePath      = "/use/api"
 )
 
 // Client for querying API


### PR DESCRIPTION
Base on gitignore documentation, the API server url is changed to
www.toptal.com domain, so use that url instead.

See: https://docs.gitignore.io/install/command-line